### PR TITLE
Float Colours

### DIFF
--- a/modules/juce_graphics/colour/juce_Colour.cpp
+++ b/modules/juce_graphics/colour/juce_Colour.cpp
@@ -547,11 +547,10 @@ Colour Colour::interpolatedWith (Colour other, float proportionOfOther) const no
         return other;
 
 #if JUCE_FLOAT_COLOURS
-    float proportionOfthis = 1.0f - proportionOfOther;
-    return Colour ((proportionOfthis * getFloatRed())   +  (proportionOfOther * other.getFloatRed()),
-                   (proportionOfthis * getFloatGreen()) +  (proportionOfOther * other.getFloatGreen()),
-                   (proportionOfthis * getFloatBlue())  +  (proportionOfOther * other.getFloatBlue()),
-                   (proportionOfthis * getFloatAlpha()) +  (proportionOfOther * other.getFloatAlpha()));
+    return Colour::fromFloatRGBA ((other.getFloatRed()   - getFloatRed())   *  proportionOfOther  +  getFloatRed(),
+                                  (other.getFloatGreen() - getFloatGreen()) *  proportionOfOther  +  getFloatGreen(),
+                                  (other.getFloatBlue()  - getFloatBlue())  *  proportionOfOther  +  getFloatBlue(),
+                                  (other.getFloatAlpha() - getFloatAlpha()) *  proportionOfOther  +  getFloatAlpha());
 #else
     PixelARGB c1 (getPixelARGB());
     PixelARGB c2 (other.getPixelARGB());

--- a/modules/juce_graphics/colour/juce_Colour.h
+++ b/modules/juce_graphics/colour/juce_Colour.h
@@ -88,6 +88,13 @@ public:
             uint8 blue,
             float alpha) noexcept;
 
+    /** Creates a colour using float red, green and blue values. */
+    Colour (float red,
+            float green,
+            float blue,
+            float alpha,
+            float) noexcept;
+
     /** Creates a colour using floating point red, green, blue and alpha values.
         Numbers outside the range 0..1 will be clipped.
     */
@@ -165,17 +172,17 @@ public:
     /** Returns the red component of this colour.
         @returns a value between 0x00 and 0xff.
     */
-    uint8 getRed() const noexcept                       { return argb.getRed(); }
+    uint8 getRed() const noexcept;
 
     /** Returns the green component of this colour.
         @returns a value between 0x00 and 0xff.
     */
-    uint8 getGreen() const noexcept                     { return argb.getGreen(); }
+    uint8 getGreen() const noexcept;
 
     /** Returns the blue component of this colour.
         @returns a value between 0x00 and 0xff.
     */
-    uint8 getBlue() const noexcept                      { return argb.getBlue(); }
+    uint8 getBlue() const noexcept;
 
     /** Returns the red component of this colour as a floating point value.
         @returns a value between 0.0 and 1.0
@@ -212,7 +219,7 @@ public:
 
         Alpha of 0x00 is completely transparent, 0xff is completely opaque.
     */
-    uint8 getAlpha() const noexcept                     { return argb.getAlpha(); }
+    uint8 getAlpha() const noexcept;
 
     /** Returns the colour's alpha (opacity) as a floating point value.
 
@@ -414,7 +421,14 @@ public:
 
 private:
     //==============================================================================
+#if JUCE_FLOAT_COLOURS
+    float r = 0.f;
+    float g = 0.f;
+    float b = 0.f;
+    float a = 0.f;
+#else
     PixelARGB argb { 0, 0, 0, 0 };
+#endif
 };
 
 } // namespace juce

--- a/modules/juce_graphics/juce_graphics.h
+++ b/modules/juce_graphics/juce_graphics.h
@@ -99,6 +99,15 @@
  #define USE_COREGRAPHICS_RENDERING 1
 #endif
 
+/** Config: JUCE_FLOAT_COLOURS
+
+    Setting this flag will make the Colour class use float values internaly instead of int allowing
+    better precision on colors
+*/
+#ifndef JUCE_FLOAT_COLOURS
+ #define JUCE_FLOAT_COLOURS 0
+#endif
+
 //==============================================================================
 namespace juce
 {

--- a/modules/juce_gui_extra/misc/juce_ColourSelector.cpp
+++ b/modules/juce_gui_extra/misc/juce_ColourSelector.cpp
@@ -30,17 +30,29 @@ struct ColourComponentSlider final : public Slider
 {
     ColourComponentSlider (const String& name)  : Slider (name)
     {
+#if JUCE_FLOAT_COLOURS
+        setRange (0.0, 255.0, 0.001);
+#else
         setRange (0.0, 255.0, 1.0);
+#endif
     }
 
     String getTextFromValue (double value) override
     {
+#if JUCE_FLOAT_COLOURS
+        return String(value, 3);
+#else
         return String::toHexString ((int) value).toUpperCase().paddedLeft ('0', 2);
+#endif
     }
 
     double getValueFromText (const String& text) override
     {
+#if JUCE_FLOAT_COLOURS
+        return (double) text.getDoubleValue();
+#else
         return (double) text.getHexValue32();
+#endif
     }
 };
 
@@ -614,10 +626,10 @@ void ColourSelector::update (NotificationType notification)
 {
     if (sliders[0] != nullptr)
     {
-        sliders[0]->setValue ((int) colour.getRed(),   notification);
-        sliders[1]->setValue ((int) colour.getGreen(), notification);
-        sliders[2]->setValue ((int) colour.getBlue(),  notification);
-        sliders[3]->setValue ((int) colour.getAlpha(), notification);
+        sliders[0]->setValue (colour.getFloatRed()   * 255.f, notification);
+        sliders[1]->setValue (colour.getFloatGreen() * 255.f, notification);
+        sliders[2]->setValue (colour.getFloatBlue()  * 255.f, notification);
+        sliders[3]->setValue (colour.getFloatAlpha() * 255.f, notification);
     }
 
     if (colourSpace != nullptr)
@@ -769,10 +781,10 @@ void ColourSelector::labelTextChanged(Label* label)
 void ColourSelector::changeColour()
 {
     if (sliders[0] != nullptr)
-        setCurrentColour (Colour ((uint8) sliders[0]->getValue(),
-                                  (uint8) sliders[1]->getValue(),
-                                  (uint8) sliders[2]->getValue(),
-                                  (uint8) sliders[3]->getValue()));
+        setCurrentColour (Colour::fromFloatRGBA (sliders[0]->getValue() / 255.f,
+                                                 sliders[1]->getValue() / 255.f,
+                                                 sliders[2]->getValue() / 255.f,
+                                                 sliders[3]->getValue() / 255.f));
 }
 
 //==============================================================================


### PR DESCRIPTION
This PR allows the JUCE Colour class to use float values internally.
In order to enable it you have to tick the **JUCE_FLOAT_COLOURS** option on the `juce_graphics` module in Projucer.

The function definitions are left untouched so activating the option shouldn't break any existing code using the class.

The Colourselector has been modified to show float values (still from 0-255 tho)
![image](https://github.com/benkuper/JUCE/assets/21125429/0619d663-2f40-4cb8-b716-4f0ae7d87b5f)
