### PR TITLE
add double/float64 type support

### DIFF
--- a/modules/juce_osc/osc/juce_OSCArgument.cpp
+++ b/modules/juce_osc/osc/juce_OSCArgument.cpp
@@ -31,6 +31,7 @@ OSCArgument::OSCArgument(bool v)                : type (v?OSCTypes::T:OSCTypes::
 OSCArgument::OSCArgument(int32 v)               : type(OSCTypes::int32),            intValue(v) {}
 OSCArgument::OSCArgument (int64 v)              : type (OSCTypes::int64),           int64Value (v) {}
 OSCArgument::OSCArgument (float v)              : type (OSCTypes::float32),         floatValue (v) {}
+OSCArgument::OSCArgument (double v)             : type (OSCtypes::float64),         doubleValue(v) {}
 OSCArgument::OSCArgument (const String& s)      : type (OSCTypes::string),          stringValue (s) {}
 OSCArgument::OSCArgument (MemoryBlock b)        : type (OSCTypes::blob),            blob (std::move (b)) {}
 OSCArgument::OSCArgument (OSCColour c)          : type (OSCTypes::colour),          intValue ((int32) c.toInt32()) {}
@@ -79,6 +80,15 @@ float OSCArgument::getFloat32() const noexcept
 
     jassertfalse; // you must check the type of an argument before attempting to get its value!
     return 0.0f;
+}
+
+double OSCArgument::getFloat64() const noexcept
+{
+	  if (isFloat64())
+		    return doubleValue;
+
+	  jassertfalse; // you must check the type of an argument before attempting to get its value!
+	  return 0.0f;
 }
 
 const MemoryBlock& OSCArgument::getBlob() const noexcept

--- a/modules/juce_osc/osc/juce_OSCArgument.h
+++ b/modules/juce_osc/osc/juce_OSCArgument.h
@@ -55,6 +55,9 @@ public:
     /** Constructs an OSCArgument with type float32 and a given value. */
     OSCArgument (float value);
 
+    /** Constructs an OSCArgument with type float64 and a given value. */
+    OSCArgument (double value);
+
     /** Constructs an OSCArgument with type string and a given value */
     OSCArgument (const String& value);
 
@@ -89,6 +92,9 @@ public:
     /** Returns whether the type of the OSCArgument is float. */
     bool isFloat32() const noexcept         { return type == OSCTypes::float32; }
 
+    /** Returns whether the type of the OSCArgument is double. */
+	  bool isFloat64() const noexcept			    { return type == OSCTypes::float64; }
+
     /** Returns whether the type of the OSCArgument is string. */
     bool isString() const noexcept          { return type == OSCTypes::string; }
 
@@ -118,6 +124,11 @@ public:
     */
     float getFloat32() const noexcept;
 
+    /** Returns the value of the OSCArgument as a float64.
+		    If the type of the OSCArgument is not float64, the behaviour is undefined.
+	  */
+	  double getFloat64() const noexcept;
+
     /** Returns the value of the OSCArgument as a string.
         If the type of the OSCArgument is not string, the behaviour is undefined.
     */
@@ -146,6 +157,7 @@ private:
     };
 
     int64 int64Value;
+    double float64Value;
     String stringValue;
     MemoryBlock blob;
 };

--- a/modules/juce_osc/osc/juce_OSCMessage.cpp
+++ b/modules/juce_osc/osc/juce_OSCMessage.cpp
@@ -115,6 +115,7 @@ void OSCMessage::addBool(bool value)                { arguments.add(OSCArgument(
 void OSCMessage::addInt32(int32 value)              { arguments.add(OSCArgument(value)); }
 void OSCMessage::addInt64 (int64 value)             { arguments.add (OSCArgument (value)); }
 void OSCMessage::addFloat32 (float value)           { arguments.add (OSCArgument (value)); }
+void OSCMessage::addFloat64 (double value)          { arguments.add (OSCArgument (value)); }
 void OSCMessage::addString (const String& value)    { arguments.add (OSCArgument (value)); }
 void OSCMessage::addBlob (MemoryBlock blob)         { arguments.add (OSCArgument (std::move (blob))); }
 void OSCMessage::addColour (OSCColour colour)       { arguments.add (OSCArgument (colour)); }

--- a/modules/juce_osc/osc/juce_OSCMessage.h
+++ b/modules/juce_osc/osc/juce_OSCMessage.h
@@ -149,6 +149,11 @@ public:
     */
     void addFloat32 (float value);
 
+    /** Creates a new OSCArgument of type float64 with the given value,
+	  and adds it to the OSCMessage object.
+    */
+	  void addFloat64(double value);
+
     /** Creates a new OSCArgument of type string with the given value,
         and adds it to the OSCMessage object.
     */

--- a/modules/juce_osc/osc/juce_OSCReceiver.cpp
+++ b/modules/juce_osc/osc/juce_OSCReceiver.cpp
@@ -99,6 +99,12 @@ namespace
             return input.readFloatBigEndian();
         }
 
+        double readFloat64()
+		    {
+			      checkBytesAvailable(8, "OSC input stream exhausted while reading double");
+			      return input.readDoubleBigEndian();
+		    }
+
         String readString()
         {
             checkBytesAvailable (4, "OSC input stream exhausted while reading string");
@@ -194,6 +200,7 @@ namespace
                 case OSCTypes::F:			return OSCArgument(false);
                 case OSCTypes::int32:       return OSCArgument (readInt32());
                 case OSCTypes::float32:     return OSCArgument (readFloat32());
+                case OSCTypes::float64:     return OSCArgument (readFloat64());
                 case OSCTypes::string:      return OSCArgument (readString());
                 case OSCTypes::blob:        return OSCArgument (readBlob());
                 case OSCTypes::colour:      return OSCArgument (readColour());

--- a/modules/juce_osc/osc/juce_OSCTypes.cpp
+++ b/modules/juce_osc/osc/juce_OSCTypes.cpp
@@ -32,6 +32,7 @@ const OSCType OSCTypes::I = 'I';
 const OSCType OSCTypes::int32 = 'i';
 const OSCType OSCTypes::int64   = 'h';
 const OSCType OSCTypes::float32 = 'f';
+const OSCType OSCTypes::float64 = 'd';
 const OSCType OSCTypes::string  = 's';
 const OSCType OSCTypes::blob    = 'b';
 const OSCType OSCTypes::colour  = 'r';

--- a/modules/juce_osc/osc/juce_OSCTypes.h
+++ b/modules/juce_osc/osc/juce_OSCTypes.h
@@ -52,6 +52,7 @@ public:
     static const OSCType int32;
     static const OSCType int64;
     static const OSCType float32;
+    static const OSCType float64;
     static const OSCType string;
     static const OSCType blob;
     static const OSCType colour;
@@ -64,6 +65,7 @@ public:
             || type == OSCTypes::int32
             || type == OSCTypes::int64
             || type == OSCTypes::float32
+            || type == OSCTypes::float64
             || type == OSCTypes::string
             || type == OSCTypes::blob
             || type == OSCTypes::colour;


### PR DESCRIPTION
Hi
This PR hopefully adds double type support for OSC.
I'm not the author of the code. The original PR, aimed at the main JUCE repo is here : https://github.com/juce-framework/JUCE/compare/master...kleblackford:JUCE:master
As it couldn't directly merge into develop-local and develop-local already had int64 support, i adapted the PR.
I hope it is not too shabby...