### PR TITLE
change right key behavior on text editor

### DIFF
--- a/modules/juce_gui_basics/widgets/juce_TextEditor.cpp
+++ b/modules/juce_gui_basics/widgets/juce_TextEditor.cpp
@@ -2001,13 +2001,19 @@ bool TextEditor::moveCaretLeft (bool moveInWholeWordSteps, bool selecting)
 
 bool TextEditor::moveCaretRight (bool moveInWholeWordSteps, bool selecting)
 {
-    auto pos = getCaretPosition();
-
-    if (moveInWholeWordSteps)
-        pos = findWordBreakAfter (pos);
+    int pos;
+    if (!moveInWholeWordSteps && !selecting && !selection.isEmpty())
+    {
+        pos = selection.getEnd();
+    }
     else
-        ++pos;
-
+    {
+        pos = getCaretPosition();
+        if (moveInWholeWordSteps)
+            pos = findWordBreakAfter(pos);
+        else
+            ++pos;
+    }
     return moveCaretWithTransaction (pos, selecting);
 }
 


### PR DESCRIPTION
A small behavior change on the "right" key when a text range is selected: it jumps to the end of the selection, instead of simply moving the caret from where it is.
All apps I use behave this way.
